### PR TITLE
Fix extra scroll on safari

### DIFF
--- a/hosting/index.html
+++ b/hosting/index.html
@@ -9,6 +9,7 @@
         align-items: center;
         height: 100vh;
         width: 100vw;
+        overflow: hidden;
       }
     </style>
   </head>


### PR DESCRIPTION
This fixes extra scroll coming due to 100vw and 100vh values set in the HTML.